### PR TITLE
Changes for Django 1.5 custom user model

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
   - "2.6"
   - "2.7"
 env:
-  - DJANGO=1.3.1
+  - DJANGO=1.5.4
 install:
   - pip install Django==$DJANGO
   - python setup.py install

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+0.3.1:
+* Django 1.5 support
+
 0.3:
 * Fix a bug in the max_age cookie setting
 * Fix packaging

--- a/README.rst
+++ b/README.rst
@@ -56,6 +56,19 @@ indicate if the user session is fresh. The name of the session var can be
 changed by setting the ``AUTH_REMEMBER_SESSION_KEY`` in you're settings file.
 
 
+If You Have a Custom User Model
+-------------------------------
+
+From Django 1.5  on wards it is possible to swap a different model in for the
+usual auth.user. In this case the migrations included in this module will not
+work, since they refer to the default user model. One workaround for this
+problem is to copy the ``auth_remember`` directory in to you project and
+either delete the ``migrations`` subdirectory (forcing it to rely on
+old-fashioned ``syncdb``), or update the migration with this command::
+
+    ./manage.py schemamigration auth_remember --update --initial
+
+
 More information
 ----------------
 

--- a/auth_remember/backend.py
+++ b/auth_remember/backend.py
@@ -1,4 +1,4 @@
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 
 from auth_remember import utils
 from auth_remember.models import RememberToken
@@ -26,6 +26,6 @@ class AuthRememberBackend(object):
 
     def get_user(self, user_id):
         try:
-            return User.objects.get(pk=user_id)
-        except User.DoesNotExist:
+            return get_user_model().objects.get(pk=user_id)
+        except get_user_model().DoesNotExist:
             return None

--- a/auth_remember/models.py
+++ b/auth_remember/models.py
@@ -1,7 +1,8 @@
 from datetime import datetime, timedelta
 
 from django.db import models
-from django.contrib.auth.models import User
+from django.utils import timezone
+from  django.conf import settings as django_settings
 
 from auth_remember import settings
 from auth_remember.auth_utils import check_password
@@ -30,10 +31,10 @@ class RememberToken(models.Model):
     token_hash = models.CharField(max_length=60, blank=False, primary_key=True)
 
     created = models.DateTimeField(editable=False, blank=True,
-        default=datetime.now)
+        default=timezone.now)
 
     created_initial = models.DateTimeField(editable=False, blank=False)
 
-    user = models.ForeignKey(User, related_name="remember_me_tokens")
+    user = models.ForeignKey(django_settings.AUTH_USER_MODEL, related_name="remember_me_tokens")
 
     objects = RememberTokenManager()

--- a/auth_remember/models.py
+++ b/auth_remember/models.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from django.db import models
 from django.utils import timezone
@@ -17,13 +17,13 @@ class RememberTokenManager(models.Manager):
         except ValueError:
             return
 
-        max_age = datetime.now() - timedelta(seconds=settings.COOKIE_AGE)
+        max_age = timezone.now() - timedelta(seconds=settings.COOKIE_AGE)
         for token in self.filter(created_initial__gte=max_age, user=user_id):
             if check_password(token_hash, token.token_hash):
                 return token
 
     def clean_remember_tokens(self):
-        max_age = datetime.now() - timedelta(seconds=settings.COOKIE_AGE)
+        max_age = timezone.now() - timedelta(seconds=settings.COOKIE_AGE)
         return self.filter(created_initial__lte=max_age).delete()
 
 

--- a/auth_remember/tests.py
+++ b/auth_remember/tests.py
@@ -1,17 +1,19 @@
 import time
 
 from django.contrib import auth
-from django.contrib.auth.models import User, AnonymousUser
+from django.contrib.auth.models import  AnonymousUser
+from django.contrib.auth import get_user_model
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.http import HttpResponse
 from django.test import TestCase
 from django.test.client import RequestFactory
 
 
+
 class TokenCreationTest(TestCase):
     def setUp(self):
-        self.user = User(username='test_user')
-        self.user.save()
+        junk_params = dict((x, x.upper()) for x in get_user_model().REQUIRED_FIELDS)
+        self.user = get_user_model().objects.create_user('TEST_USER', password='PASSWORD', **junk_params)
 
     def test_create_token_string(self):
         from auth_remember.utils import create_token_string
@@ -44,9 +46,8 @@ class TokenCreationTest(TestCase):
 
 class AuthTest(TestCase):
     def setUp(self):
-        self.user = User(username='test_user')
-        self.user.set_password('secret')
-        self.user.save()
+        junk_params = dict((x, x.upper()) for x in get_user_model().REQUIRED_FIELDS)
+        self.user = get_user_model().objects.create_user('test_user', password='secret', **junk_params)
         self.factory = RequestFactory()
 
     def test_auth_backend(self):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages, Command
 
 
 install_requires = [
-    'Django>=1.3',
+    'Django>=1.5',
 ]
 
 
@@ -50,7 +50,7 @@ with open('README.rst', 'r') as fh:
 
 setup(
     name='django-auth-remember',
-    version='0.3',
+    version='0.3.1',
     url='https://github.com/ailabs/django-auth-remember/',
     license='MIT',
     author='Michael van Tellingen',


### PR DESCRIPTION
The main differences here are that it uses the new `get_user_model` method to find the project’s user model, and also uses `django.utils.timezone.now` in preference to `datetime.now`, avoiding annoying complaints about naïve timestamps.

I don’t know how to make a South migration work with a configurable user model so I ended up punting on that.
